### PR TITLE
feature/markdown-it nearly live rendering

### DIFF
--- a/website/static/js/markdown.js
+++ b/website/static/js/markdown.js
@@ -1,6 +1,8 @@
 var hljs = require('highlight.js');
 require('highlight-css');
-var markdown = require('markdown-it')('commonmark', {
+var MarkdownIt = require('markdown-it')
+
+var markdown = new MarkdownIt('commonmark', {
     highlight: function (str, lang) {
         if (lang && hljs.getLanguage(lang)) {
             try {
@@ -18,4 +20,23 @@ var markdown = require('markdown-it')('commonmark', {
     .use(require('markdown-it-video'))
     .use(require('markdown-it-sanitizer'));
 
+var markdown_quick = new MarkdownIt(('commonmark'), {
+     highlight: function (str, lang) {
+        if (lang && hljs.getLanguage(lang)) {
+            try {
+                return hljs.highlight(lang, str).value;
+            } catch (__) {}
+        }
+
+        try {
+            return hljs.highlightAuto(str).value;
+        } catch (__) {}
+
+        return ''; // use external default escaping
+    }
+})
+    .use(require('markdown-it-sanitizer'))
+    .disable('image');
+
 module.exports = markdown;
+module.exports = markdown_quick;

--- a/website/static/js/markdown.js
+++ b/website/static/js/markdown.js
@@ -1,9 +1,8 @@
 var hljs = require('highlight.js');
 require('highlight-css');
-var MarkdownIt = require('markdown-it')
+var MarkdownIt = require('markdown-it');
 
-var markdown = new MarkdownIt('commonmark', {
-    highlight: function (str, lang) {
+highlighter = function (str, lang) {
         if (lang && hljs.getLanguage(lang)) {
             try {
                 return hljs.highlight(lang, str).value;
@@ -15,25 +14,19 @@ var markdown = new MarkdownIt('commonmark', {
         } catch (__) {}
 
         return ''; // use external default escaping
-    }
+    };
+
+// Full markdown renderer for views / wiki pages / pauses between typing
+var markdown = new MarkdownIt('commonmark', {
+    highlight: highlighter
 })
     .use(require('markdown-it-video'))
     .use(require('markdown-it-sanitizer'));
 
+
+// Fast markdown renderer for active editing to prevent slow loading/rendering tasks
 var markdown_quick = new MarkdownIt(('commonmark'), {
-     highlight: function (str, lang) {
-        if (lang && hljs.getLanguage(lang)) {
-            try {
-                return hljs.highlight(lang, str).value;
-            } catch (__) {}
-        }
-
-        try {
-            return hljs.highlightAuto(str).value;
-        } catch (__) {}
-
-        return ''; // use external default escaping
-    }
+     highlight: highlighter
 })
     .use(require('markdown-it-sanitizer'))
     .disable('image');


### PR DESCRIPTION
## Purpose

Make quick vs full version of markdown renderer for live editing vs. nearly live editing and normal rendering.
## Changes

Added a quick rendering markdown-it instance that doesn't have image or video rendering. I also refactored it a bit to reuse code better. To use, you just need to use the quick markdown renderer for live editing all the time, and the full renderer for live editing after the editors pause. 
## Side Effects

This is… not tested. Like, at _all_. But it should be pretty much what you need. If I get to the point where I have tested it on your branch before you get a chance to try it, then I'll update this PR to let you know.
